### PR TITLE
BMP-11968-B -- Add user input for page type

### DIFF
--- a/deploy-branch.sh
+++ b/deploy-branch.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Default to main branch if not specified
+BRANCH=${2:-main}
+
+# Check if we need to switch branches
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
+    echo "Switching to branch: $BRANCH"
+    git checkout "$BRANCH" || { echo "Branch $BRANCH does not exist"; exit 1; }
+fi
+
+# Continue with the original script
+version=$(sed -n 's/.*"version": "\(.*\)",/\1/p' dist/syphonx/manifest.json)
+last_tag=$(git describe --tags --abbrev=0)
+echo "Current version is v$version"
+echo "Last release version is $last_tag"
+
+# exit if version is empty
+if [ -z "$version" ]; then
+  echo "No build output found."
+  exit 1
+fi
+
+# exit if version is not updated
+if [ "v$version" = "$last_tag" ] && [ "$1" != "-f" ]; then
+  echo "Update version in manifest.json. Use -f to bypass this check."
+  exit 1
+fi
+
+# exit if there are uncommitted changes
+git_status=$(git status --porcelain)
+if [ -n "$git_status" ] && [ "$1" != "-f" ]; then
+    echo "There are uncommitted changes in the repository. Use -f to bypass this check."
+    exit 1
+fi
+
+pushd dist
+zip -r syphonx-"$version".zip syphonx
+gh release create "v$version" syphonx-"$version".zip \
+    --prerelease \
+    --generate-notes \
+    --target "$BRANCH"
+popd
+
+# Switch back to the original branch if we changed branches
+if [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
+    echo "Switching back to branch: $CURRENT_BRANCH"
+    git checkout "$CURRENT_BRANCH"
+fi

--- a/devnotes.md
+++ b/devnotes.md
@@ -50,6 +50,10 @@ sudo apt-get install gh
 1. Commit and push to main
 2. Run `yarn deploy` to publish a release
 
+## Deploy a specific branch
+1. Commit your changes locally -- update PR with changes
+2. run `yarn deploy-branch <your-branch>` to publish a release for that specific branch
+
 ## Re-Deploy
 1. Run `gh release delete v0.9.9` to delete an existing release
 2. Run `git tag -d v0.9.9` to delete the corresponding tag

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "bash ./build.sh",
     "deploy": "bash ./deploy.sh",
+    "deploy-branch": "bash ./deploy-branch.sh",
     "clean": "bash ./clean.sh",
     "test": "node --experimental-specifier-resolution=node ./node_modules/mocha/lib/cli/cli.js --config .mocharc.yml"
   },

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "SyphonX",
-    "version": "0.9.21",
+    "version": "0.9.22",
     "manifest_version": 3,
     "minimum_chrome_version": "10.0",
     "icons": {

--- a/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
@@ -28,9 +28,7 @@ import {
 
 } from "@mui/icons-material";
 
-// const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
-const api = new RestApi("http:localhost:8081");
-
+const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
 export interface Props {
     open: boolean;
     onClose: (event: React.SyntheticEvent) => void;

--- a/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
@@ -28,7 +28,8 @@ import {
 
 } from "@mui/icons-material";
 
-const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
+// const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
+const api = new RestApi("http:localhost:8081");
 
 export interface Props {
     open: boolean;
@@ -171,12 +172,13 @@ export default ({ open, onClose }: Props) => {
         setLate(false);
         try {
             const headers: Record<string, string> = { Authorization: `Bearer u/${user?.id}`, "X-Username": `${user?.email}` };
-            let params = `?workstream=${encodeURIComponent(autorun?.workstream?.workstream_id!)}`;
+            let params = `?workstream=${encodeURIComponent(autorun?.workstream?.workstream_id!)}&page_type=${encodeURIComponent(autorun?.pageType!)}`;
             if (autorun?.mode === "include" && !isEmpty(autorun.domains))
                 params += `&include=${encodeURIComponent(autorun.domains!.join(","))}`;
             else if (autorun?.mode === "exclude" && !isEmpty(autorun.domains))
                 params += `&exclude=${encodeURIComponent(autorun.domains!.join(","))}`;
             const template = await api.json("/autorun", { headers, params });
+            console.log(template)
             if (template?.url) {
                 setStatus("Running");
                 setId(template.id);

--- a/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
@@ -152,7 +152,7 @@ export default ({ open, onClose }: Props) => {
         }
         catch (err) {
             setError(err instanceof Error ? err.message : JSON.stringify(err));
-            setStatus("Stopped");
+            setStatus("Empty");
             setActive(false);
         }
 

--- a/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
@@ -176,7 +176,6 @@ export default ({ open, onClose }: Props) => {
             else if (autorun?.mode === "exclude" && !isEmpty(autorun.domains))
                 params += `&exclude=${encodeURIComponent(autorun.domains!.join(","))}`;
             const template = await api.json("/autorun", { headers, params });
-            console.log(template)
             if (template?.url) {
                 setStatus("Running");
                 setId(template.id);

--- a/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunDialog.tsx
@@ -28,7 +28,10 @@ import {
 
 } from "@mui/icons-material";
 
-const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
+const apiUrl = 'https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service'
+
+const api = new RestApi(apiUrl);
+
 export interface Props {
     open: boolean;
     onClose: (event: React.SyntheticEvent) => void;
@@ -79,6 +82,9 @@ export default ({ open, onClose }: Props) => {
             setTimer(value);            
         }
         else if (status === "Running" && !timer) {
+            if (!active) {
+                setActive(true)
+            }
             const value = setTimeout(() => {
                 setTimer(undefined);
                 setLate(true);
@@ -150,7 +156,7 @@ export default ({ open, onClose }: Props) => {
         }
         catch (err) {
             setError(err instanceof Error ? err.message : JSON.stringify(err));
-            setStatus("Empty");
+            setStatus("Idle");
             setActive(false);
         }
 
@@ -161,7 +167,7 @@ export default ({ open, onClose }: Props) => {
         else if (refreshing && !late)
             setStatus("Stopping");
         else
-            setStatus("Stopped");
+            setStatus("Idle");
     }
 
     async function next() {
@@ -192,7 +198,7 @@ export default ({ open, onClose }: Props) => {
             }
         }
         catch (err) {
-            setStatus("Stopped");
+            setStatus("Idle");
             setError(err instanceof Error ? err.message : JSON.stringify(err));
             setActive(false);
         }
@@ -257,7 +263,7 @@ export default ({ open, onClose }: Props) => {
                         <Button variant="outlined" onClick={async () => await next()} sx={{ width: 300 }}>Next Page</Button>
                         {extractState?.domain && <Button variant="outlined" onClick={() => skip(extractState?.domain)} sx={{ width: 300 }}>Skip&nbsp;<small>{extractState.domain}</small></Button>}
                     </Stack>}
-                    {["Pausing", "Stopping", "Stopped"].includes(status) && id && !refreshing && <>
+                    {["Pausing", "Stopping", "Stopped", "Idle"].includes(status) && id && !refreshing && <>
                         <TableView />
                         {blocked && <Chip label="Blocked" variant="filled" color="error" icon={<BlockedIcon fontSize="small" />} size="small" sx={{ mt: 1, width: "fit-content" }} />}
                         {pnf && <Chip label="Page Not Found" variant="filled" color="warning" icon={<UnknownIcon fontSize="small" />} size="small" sx={{ mt: 1, width: "fit-content" }} />}

--- a/src/panel/TemplateEditor/Sidebar/AutorunSettingsDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunSettingsDialog.tsx
@@ -21,8 +21,8 @@ import {
 } from "@mui/material";
 import AutorunPageTypeSelect from "../components/AutorunPageTypeSelect";
 
-// const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
-const api = new RestApi("http://localhost:8081");
+const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
+
 const default_workstream = { workstream_id: "default", workstream_name: "default" } as Workstream;
 
 export interface Props {

--- a/src/panel/TemplateEditor/Sidebar/AutorunSettingsDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunSettingsDialog.tsx
@@ -19,8 +19,10 @@ import {
     TextField,
     Typography
 } from "@mui/material";
+import AutorunPageTypeSelect from "../components/AutorunPageTypeSelect";
 
-const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
+// const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
+const api = new RestApi("http://localhost:8081");
 const default_workstream = { workstream_id: "default", workstream_name: "default" } as Workstream;
 
 export interface Props {
@@ -33,6 +35,9 @@ interface Workstream {
     workstream_name: string;
 }
 
+const pageTypes = ['category', 'product', 'search']
+
+
 export default ({ open, onClose }: Props) => {
     const { autorun, setAutorun, inspectedWindowUrl } = useApp();
     const { user } = useTemplate();
@@ -43,6 +48,7 @@ export default ({ open, onClose }: Props) => {
 
     const [workstreams, setWorkstreams] = React.useState<Workstream[]>([ ]);
     const [workstream, setWorkstream] = React.useState<Workstream>();
+    const [pageType, setPageType] = React.useState<string>("product");
 
     useEffect(() => {
         if (open) {
@@ -65,7 +71,8 @@ export default ({ open, onClose }: Props) => {
         setAutorun({
             mode,
             domains: domains?.split("\n").map((value: string) => value.trim()).filter((value: string) => value.length > 0),
-            workstream: workstream && workstreams.find((item: Workstream) => item.workstream_id === workstream.workstream_id)
+            workstream: workstream && workstreams.find((item: Workstream) => item.workstream_id === workstream.workstream_id),
+            pageType: pageType || "product"
         });
         onClose(event);
     }
@@ -95,6 +102,10 @@ export default ({ open, onClose }: Props) => {
     function handleWorkstreamSelection(workstream: Workstream) {
         setWorkstream(workstream);
     }
+    
+    function handlePagetypeSelection(pageType: string) {
+        setPageType(pageType);
+    }
 
     return (
         <Dialog open={open} onClose={onClose}>
@@ -103,6 +114,9 @@ export default ({ open, onClose }: Props) => {
                 <Stack direction="column">
                     <Stack direction="row" justifyContent="space-between" alignItems="center">
                         {workstreams?.length ? <AutorunWorkstreamSelect workstreams={workstreams} onChange={handleWorkstreamSelection} /> : <></>}
+                    </Stack>
+                    <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <AutorunPageTypeSelect pageTypes={pageTypes} onChange={handlePagetypeSelection} />
                     </Stack>
                     <FormControl>
                         <RadioGroup value={mode} onChange={(event, value) => setMode(value as "all" | "include" | "exclude")}>

--- a/src/panel/TemplateEditor/Sidebar/AutorunSettingsDialog.tsx
+++ b/src/panel/TemplateEditor/Sidebar/AutorunSettingsDialog.tsx
@@ -21,7 +21,9 @@ import {
 } from "@mui/material";
 import AutorunPageTypeSelect from "../components/AutorunPageTypeSelect";
 
-const api = new RestApi("https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service");
+const apiUrl = "https://us-central1-ps-bigdata.cloudfunctions.net/syphonx-service"
+
+const api = new RestApi(apiUrl);
 
 const default_workstream = { workstream_id: "default", workstream_name: "default" } as Workstream;
 

--- a/src/panel/TemplateEditor/components/AutorunPageTypeSelect.tsx
+++ b/src/panel/TemplateEditor/components/AutorunPageTypeSelect.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+    PaperProps: {
+        style: {
+            maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+            width: 250,
+        },
+    },
+};
+
+interface Props {
+    pageTypes: string[];
+    onChange: (pageType: string) => void
+}
+
+
+export default ({ pageTypes, onChange }: Props) => {
+    const handleChange = (event: SelectChangeEvent<string>) => {
+        const { target: { value } } = event;
+        const pageType: string = pageTypes.find(item => item === value)!;
+        setPageType(pageType);
+        onChange(pageType);
+    };
+
+    const [pageType, setPageType] = React.useState<string>('product');
+
+    return (
+        <div>
+            <FormControl sx={{ m: 1, width: 300 }}>
+                <InputLabel id="pageType-label">Page Type</InputLabel>
+                <Select
+                    labelId="pageType-label"
+                    id="pageType-id"
+                    value={pageType}
+                    onChange={handleChange}
+                    input={<OutlinedInput label="Page Types" />}
+                    MenuProps={MenuProps}
+                >
+                    {pageTypes.map((pageType) => (
+                        <MenuItem
+                            key={pageType}
+                            value={pageType}
+                        >
+                            {pageType}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+        </div>
+    );
+}

--- a/src/panel/TemplateEditor/context/DataContext.tsx
+++ b/src/panel/TemplateEditor/context/DataContext.tsx
@@ -73,9 +73,11 @@ export function DataProvider({ children }: { children: JSX.Element }) {
              url = `https://${template.url}`;
         }
 
-        if (url && url?.includes('<search_phrase>')) {
+        if (url && url?.includes('<search_phrase>'))
             url = url.replace('<search_phrase>', String(template?.params?.search));
-        }
+
+        if (url && url?.includes('$params.search'))
+            url = url.replace('$params.search', String(template?.params?.search));
         
         url = expandTemplateUrl(url, template.params);
         await inspectedWindow.navigate(url);

--- a/src/panel/TemplateEditor/context/DataContext.tsx
+++ b/src/panel/TemplateEditor/context/DataContext.tsx
@@ -66,6 +66,12 @@ export function DataProvider({ children }: { children: JSX.Element }) {
             url = template.url; 
         else if (!url)
             return;
+        
+
+        if (!template.url?.includes("https://")) {
+             console.info(`Template url is missing protocol: ${template.url}`)
+             url = `https://${template.url}`;
+        }
 
         url = expandTemplateUrl(url, template.params);
         await inspectedWindow.navigate(url);

--- a/src/panel/context.tsx
+++ b/src/panel/context.tsx
@@ -13,6 +13,7 @@ export interface AutorunSettings {
     mode?: "all" | "include" | "exclude";
     domains?: string[];
     workstream?: Workstream;
+    pageType?: string;
 }
 
 export interface AppState {


### PR DESCRIPTION
#### What is the purpose of this PR?
Create a new user input for adding page_type -- updates to the backend made this a requirement since we're crawling more than one type of page.
#### Where should the reviewer start?
AutoRunDialog
DataContext
#### How should this be manually tested?

#### Any background context you want to provide?
I also had to add handling for search urls since we are running into security issues evaluating the script for search urls tagged with brackets. For now we handle searches for walmart/amazon but will have to find another solution that is more generalized for any/all search pages.
#### What are the relevant tickets?
https://pricespider.atlassian.net/browse/BMP-11970 -- handling search templates
https://pricespider.atlassian.net/browse/BMP-11968 --  new user input
https://pricespider.atlassian.net/browse/BMP-11973 -- handle errors from service and continue crawling.
#### Screenshots/ Video (if appropriate)
![Screenshot 2025-02-21 at 10 52 20 AM](https://github.com/user-attachments/assets/80f20d9e-1dde-4e34-b7a1-633a5aed546d)

#### Questions:
